### PR TITLE
Add ACER/MAZE exams to blacklist

### DIFF
--- a/classhub.js
+++ b/classhub.js
@@ -1058,7 +1058,9 @@
     "essentialassessment.com.au",
     "www.essentialassessment.com.au",
     "acer.edu.au",
-    "www.acer.edu.au"
+    "www.acer.edu.au",
+    "alo.acadiencelearning.org",
+    "www.alo.acadiencelearning.org"
   ];
   const currentSite = window.location.hostname;
   if (blacklistedSites.includes(currentSite)) {

--- a/classhub.js
+++ b/classhub.js
@@ -1057,8 +1057,9 @@
   const blacklistedSites = [
     "essentialassessment.com.au",
     "www.essentialassessment.com.au",
-    // add pat maths
-  ];
+    "acer.edu.au",
+    "www.acer.edu.au"
+    ];
   const currentSite = window.location.hostname;
   if (blacklistedSites.includes(currentSite)) {
     document.body.innerHTML =

--- a/classhub.js
+++ b/classhub.js
@@ -1059,7 +1059,7 @@
     "www.essentialassessment.com.au",
     "acer.edu.au",
     "www.acer.edu.au"
-    ];
+  ];
   const currentSite = window.location.hostname;
   if (blacklistedSites.includes(currentSite)) {
     document.body.innerHTML =

--- a/classhub.js
+++ b/classhub.js
@@ -1057,6 +1057,7 @@
   const blacklistedSites = [
     "essentialassessment.com.au",
     "www.essentialassessment.com.au",
+    // add pat maths
   ];
   const currentSite = window.location.hostname;
   if (blacklistedSites.includes(currentSite)) {


### PR DESCRIPTION
## General Changes
Added `acer.edu.au` and `alo.acadiencelearning.org` to the blacklist.
## OLD CODE
```
  const blacklistedSites = [
    "essentialassessment.com.au",
    "www.essentialassessment.com.au",
  ];
```
## UPDATED CODE
```
  const blacklistedSites = [
    "essentialassessment.com.au",
    "www.essentialassessment.com.au",
    "acer.edu.au",
    "www.acer.edu.au",
    "alo.acadiencelearning.org",
    "www.alo.acadiencelearning.org"
  ];
```